### PR TITLE
#29: Show a loader while data is fetching (closes #29)

### DIFF
--- a/src/components/LoadingSpinner/LoadingSpinner.js
+++ b/src/components/LoadingSpinner/LoadingSpinner.js
@@ -1,0 +1,2 @@
+import './loadingSpinner.scss';
+export default from 'buildo-react-components/lib/loading-spinner';

--- a/src/components/LoadingSpinner/index.js
+++ b/src/components/LoadingSpinner/index.js
@@ -1,0 +1,1 @@
+export default from './LoadingSpinner';

--- a/src/components/LoadingSpinner/loadingSpinner.scss
+++ b/src/components/LoadingSpinner/loadingSpinner.scss
@@ -1,0 +1,1 @@
+@import '~buildo-react-components/src/loading-spinner/loadingSpinner.scss';

--- a/src/routes/Search.js
+++ b/src/routes/Search.js
@@ -41,13 +41,14 @@ export default class Search extends React.Component {
   }
 
   render() {
+    const isFetching = this.state.isFetching;
     const errorResult = this.state.errorMsg !== null;
-    const undefinedResult = !errorResult && (typeof this.state.repositories === 'undefined' || this.state.repositories === null);
-    const emptyResult = !errorResult && !undefinedResult && this.state.repositories.length === 0;
-    const foundResult = !errorResult && !undefinedResult && this.state.repositories.length > 0; //simply !undefinedResult && !emptyResult
+    const undefinedResult = !isFetching && !errorResult && (typeof this.state.repositories === 'undefined' || this.state.repositories === null);
+    const emptyResult = !isFetching && !errorResult && !undefinedResult && this.state.repositories.length === 0;
+    const foundResult = !isFetching && !errorResult && !undefinedResult && this.state.repositories.length > 0; //simply !undefinedResult && !emptyResult
     return (
       <FlexView hAlignContent='center' column grow>
-        {this.state.isFetching &&
+        {isFetching &&
         (<div style={{ position: 'relative', height: 300 }}>
           <LoadingSpinner
             size={50}

--- a/src/routes/Search.js
+++ b/src/routes/Search.js
@@ -21,9 +21,10 @@ export default class Search extends React.Component {
   }
 
   fetchRepositories = (q) => {
+    this.setState({ repositories: null, errorMsg: null, isFetching: false });
     if (typeof q !== 'undefined' && q !== null && q.trim() !== '') {
       //reset the states
-      this.setState({ repositories: null, errorMsg: null, isFetching: true });
+      this.setState({ isFetching: true });
       axios.get('http://api.github.com/search/repositories', { params: { q } })
       .then(this.assignRespositories)
       .catch(this.errorHandler); // eslint-disable-line
@@ -49,13 +50,13 @@ export default class Search extends React.Component {
     return (
       <FlexView hAlignContent='center' column grow>
         {isFetching &&
-        (<div style={{ position: 'relative', height: 300 }}>
+        (<div style={{ position: 'relative', height: 300, width: '100%' }}>
           <LoadingSpinner
             size={50}
             message={{ content: 'Loading ...' }}
           />
         </div>)}
-        {undefinedResult && <UndefinedResult />} //should be shown when no search is done
+        {undefinedResult && <UndefinedResult />}
         {errorResult && <ErrorResult errorMsg={this.state.errorMsg} />}
         {emptyResult && <EmptyResult />}
         {foundResult && <SearchResultPanel items={this.state.repositories} />}

--- a/src/routes/Search.js
+++ b/src/routes/Search.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { RouteHandler } from 'react-router';
 import axios from 'axios';
 import FlexView from 'react-flexview';
+import LoadingSpinner from '../components/LoadingSpinner';
 import SearchResultPanel from 'components/Search/SearchResultPanel';
 import EmptyResult from 'components/Search/EmptyResult';
 import UndefinedResult from 'components/Search/UndefinedResult';
@@ -9,18 +10,20 @@ import ErrorResult from 'components/Search/ErrorResult';
 
 export default class Search extends React.Component {
 
-  state = { repositories: null, errorMsg: null };
+  state = { repositories: null, errorMsg: null, isFetching: false };
 
   assignRespositories = (response) => {
-    this.setState({ repositories: response.data.items, errorMsg: null });
+    this.setState({ repositories: response.data.items, errorMsg: null, isFetching: false });
   }
 
   errorHandler = () => {
-    this.setState({ repositories: null, errorMsg: 'Search failed!' });
+    this.setState({ repositories: null, errorMsg: 'Search failed!', isFetching: false });
   }
 
   fetchRepositories = (q) => {
     if (typeof q !== 'undefined' && q !== null && q.trim() !== '') {
+      //reset the states
+      this.setState({ repositories: null, errorMsg: null, isFetching: true });
       axios.get('http://api.github.com/search/repositories', { params: { q } })
       .then(this.assignRespositories)
       .catch(this.errorHandler); // eslint-disable-line
@@ -42,11 +45,17 @@ export default class Search extends React.Component {
     const undefinedResult = !errorResult && (typeof this.state.repositories === 'undefined' || this.state.repositories === null);
     const emptyResult = !errorResult && !undefinedResult && this.state.repositories.length === 0;
     const foundResult = !errorResult && !undefinedResult && this.state.repositories.length > 0; //simply !undefinedResult && !emptyResult
-
     return (
       <FlexView hAlignContent='center' column grow>
+        {this.state.isFetching &&
+        (<div style={{ position: 'relative', height: 300 }}>
+          <LoadingSpinner
+            size={50}
+            message={{ content: 'Loading ...' }}
+          />
+        </div>)}
+        {undefinedResult && <UndefinedResult />} //should be shown when no search is done
         {errorResult && <ErrorResult errorMsg={this.state.errorMsg} />}
-        {undefinedResult && <UndefinedResult />}
         {emptyResult && <EmptyResult />}
         {foundResult && <SearchResultPanel items={this.state.repositories} />}
         <RouteHandler />


### PR DESCRIPTION
Issue #29
## Test Plan
### tests performed

passing search query:
1. go to http://localhost:8080/#/
2. enter "react" to the search input text, 
3. Click enter, or press the search button
it will be redirected to the search page, and the loading spinner should be shown, then the results
### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.
> 
> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
