### PR TITLE
#32: Handle empty input searches (closes #32)

### DIFF
--- a/src/routes/Search.js
+++ b/src/routes/Search.js
@@ -20,9 +20,11 @@ export default class Search extends React.Component {
   }
 
   fetchRepositories = (q) => {
-    axios.get('http://api.github.com/search/repositories', { params: { q } })
-    .then(this.assignRespositories)
-    .catch(this.errorHandler); // eslint-disable-line
+    if (typeof q !== 'undefined' && q !== null && q.trim() !== '') {
+      axios.get('http://api.github.com/search/repositories', { params: { q } })
+      .then(this.assignRespositories)
+      .catch(this.errorHandler); // eslint-disable-line
+    }
   }
 
   componentDidMount() {


### PR DESCRIPTION
Issue #32
## Test Plan
### tests performed

try to modify the url manually by deleting the query string: 
http://localhost:8080/#/search?query=
No search will be done, and the previous search results should remain on the page

Try again to enter the url: 
http://localhost:8080/#/search
the search page will be loaded with the default message "Searh the repo in the top-bar to see the results"
in the result panel.
### tests not performed (domain coverage)

> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.
> 
> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
